### PR TITLE
Fix race condition between creating DEBIAN/control and executing dpkg-deb

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,19 +43,30 @@ module.exports = function(pkg) {
             ctrl = ctrl.filter(function(line) {
                 if(!/Out|Target|Verbose/.test(line))
                     return line;
-            })
-            ws.write(ctrl.join('\n'));
-            files.map(function(f) {
-                let t = f.path.split('/');
-                t = t[t.length - 1];
-                fs.copySync(f.path, `${out}/${pkg._target}/${t}`);
             });
-            _exec(`dpkg-deb --build ${pkg._out}/${pkg.package}_${pkg.version}`,
-            function(err, stdout, stderr) {
-                if(pkg._verbose && stdout.length > 1) gutil.log(stdout.trim());
-                if(stderr) gutil.log(gutil.colors.red(stderr.trim()));
-                cb(err);
+
+            ws.write(ctrl.join('\n'), function (result) {
+
+                if (result instanceof Error) {
+                    cb(new gutil.PluginError('gulp-debian', result));
+                    return;
+                }
+
+                files.map(function(f) {
+                    let t = f.path.split('/');
+                    t = t[t.length - 1];
+                    fs.copySync(f.path, `${out}/${pkg._target}/${t}`);
+                });
+                
+                _exec(`dpkg-deb --build ${pkg._out}/${pkg.package}_${pkg.version}`,
+                function(err, stdout, stderr) {
+                    if(pkg._verbose && stdout.length > 1) gutil.log(stdout.trim());
+                    if(stderr) gutil.log(gutil.colors.red(stderr.trim()));
+                    cb(err);
+                });
+                
             });
+
         });
     });
 };


### PR DESCRIPTION
nodejs [writable.write](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback) is asynchronous. Because this library did not treat it as such, there was a race condition between ws.write() and _exec(`dpkg-deb --build` ...).

This change places subsequent commands inside ws.write callback, to remove race condition between writing the control file and reading it.