### PR TITLE
Add prerm, postrm and _clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ gulp.task('default', function (done) {
     description: 'A dummy package',
     preinst: [ 'echo "hello from dummy package"' ],
     postinst: [ 'cat -n /opt/demo/.npmignore' ],
+    prerm: [ 'cat -n /opt/demo/.npmignore' ],
+    postrm: [ 'echo "bye from dummy package"' ],
     changelog: [
       {
         version: '0.1-2',
@@ -55,6 +57,7 @@ gulp.task('default', function (done) {
     ],
     _target: 'opt/demo',
     _out: 'dist',
+    _clean: true,
     _verbose: true
   }))
   done()
@@ -88,17 +91,20 @@ gulp.task('default', function (done) {
 ##### Options
 
 * Options: Object containing properties for a Debian file and the following parameters:
-  	* preinst: Array of commands to run for the package's *pre-install* script (optional).
-  	* postint: Array of commmands to run for the package's *post-install* script (optional).
-  	* changelog: Array of versions and their changes to write to the package's *changelog* (optional, but recommended). Options are:
-  		* version: String for version with changes.
-  		* distribution: String for version distribution.
-  		* urgency: String for version urgency.
-  		* date: Date object or String in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) notation for version date.
-  		* changes: Array of changes made.
-	* _target: string - The installation target for the created Debian package (mandatory).
-	* _out: string - The target directory to create the Debian package in (mandatory).
-	* _verbose: boolean - Verbose output from dpkg-deb utility (optional; true if omitted).
+    * preinst: Array of commands to run for the package's *pre-install* script (optional).
+    * postint: Array of commmands to run for the package's *post-install* script (optional).
+    * prerm: Array of commands to run for the package's *pre-remove* script (optional).
+    * postrm: Array of commmands to run for the package's *post-remove* script (optional).
+    * changelog: Array of versions and their changes to write to the package's *changelog* (optional, but recommended). Options are:
+        * version: String for version with changes.
+        * distribution: String for version distribution.
+        * urgency: String for version urgency.
+        * date: Date object or String in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) notation for version date.
+        * changes: Array of changes made.
+    * _target: string - The installation target for the created Debian package (mandatory).
+    * _out: string - The target directory to create the Debian package in (mandatory).
+    * _clean: boolean - If true, removes the temporary directory created in the target directory with the same structure than the Debian package.
+    * _verbose: boolean - Verbose output from dpkg-deb utility (optional; true if omitted).
 
   (or)
 

--- a/index.js
+++ b/index.js
@@ -75,8 +75,10 @@ module.exports = function (pkg) {
       let out = `${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`
       installScript('preinst', pkg.preinst, out, cb)
       installScript('postinst', pkg.postinst, out, cb)
+      installScript('prerm', pkg.prerm, out, cb)
+      installScript('postrm', pkg.postrm, out, cb)
       ctrl = ctrl.filter(function (line) {
-        if (!/Out|Target|Verbose|Changelog|Preinst|Postinst/.test(line)) {
+        if (!/Out|Target|Verbose|Changelog|Preinst|Postinst|Prerm|Postrm|Clean/.test(line)) {
           return line
         }
       })
@@ -121,6 +123,9 @@ module.exports = function (pkg) {
         })
         _exec(`dpkg-deb --build ${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`,
         function (err, stdout, stderr) {
+          if (pkg._clean) {
+            fs.removeSync(`${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`)
+          }
           if (pkg._verbose && stdout.length > 1) {
             gutil.log(stdout.trim() + '\n')
           }


### PR DESCRIPTION
Fixes https://github.com/stpettersens/gulp-debian/issues/9

Adds CONTROL `prerm` script and `postrm` script.
Adds `_clean` parameter (true/false) to delete the temporary folder generated in the output to package into the deb file.