### PR TITLE
Call end callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,8 @@ module.exports = function (pkg) {
           }
           if (stderr) {
             gutil.log(gutil.colors.red(stderr.trim()))
-            cb(err)
           }
+          cb(err)
         })
       })
     })


### PR DESCRIPTION
The code is not calling the callback (or returning the stream) when ending the execution.

Under gulp 3 and being the latest stream, this bug is not detected (only the message of end task does not appear), but with gulp 4 an error message appears.

I'm not sure if my solution is the best, it works but maybe there is better solution. @stpettersens can you review the code to see if there's a better solution? I think that this bug is important and needs a fast solution 😉