### PR TITLE
Changelog gzip/dpkg-deb race condition removed; Date/time correction …

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -24,11 +24,11 @@ gulp.task('deb-inline', function () {
   .pipe(deb({
     package: 'demo',
     version: '0.1-2',
-    section: 'base',
+    section: 'devel',
     priority: 'optional',
     architecture: 'i386',
     maintainer: 'Mr. Apt <apt@nowhere.tld>',
-    description: 'A dummy package\n Long description starts here...',
+    description: 'Dummy package\n Long description starts here...',
     preinst: 'test/preinst',
     postinst: [ 'cat -n /opt/demo/.npmignore' ],
     changelog: [

--- a/demo_0.1-2_i386.json
+++ b/demo_0.1-2_i386.json
@@ -1,11 +1,11 @@
 {
     "package": "demo-from-json",
     "version": "0.1-2",
-    "section": "base",
+    "section": "devel",
     "priority": "optional",
     "architecture": "i386",
     "maintainer": "Mr. Apt <apt@nowhere.tld>",
-    "description": "A dummy package\n Long description starts here...",
+    "description": "Dummy package\n Long description starts here...",
     "preinst": "test/preinst",
     "postinst": [
         "cat -n /opt/demo/.gitignore"

--- a/index.js
+++ b/index.js
@@ -147,7 +147,6 @@ module.exports = function (pkg) {
       })
 
       writeChangelog(pkg, out, cb)
-      
       /* @lucomsky's commit replaced this.
       Kept only for reference. Will remove in future:
       const logf = changelog(pkg)
@@ -178,7 +177,6 @@ module.exports = function (pkg) {
         })
       }
       */
-      
       const ctrlf = ctrl.join('\n')
       fs.outputFile(`${out}/DEBIAN/control`, ctrlf.substr(0, ctrlf.length - 1),
       function (err) {

--- a/index.js
+++ b/index.js
@@ -94,6 +94,16 @@ function installCopyright (pn, path, out, cb) {
   }
 }
 
+function chmodRegularFile (path, cb) {
+  if (fs.statSync(path).isFile()) {
+    fs.chmodSync(path, parseInt(`0${fileMode}`, 8))
+  } else {
+    fs.readdirSync(path).forEach(file => {
+      chmodRegularFile(`${path}/${file}`, cb)
+    })
+  }
+}
+
 module.exports = function (pkg) {
   let files = []
   return through.obj(function (file, enc, cb) {
@@ -146,7 +156,7 @@ module.exports = function (pkg) {
           let t = f.path.split('/')
           t = t[t.length - 1]
           fs.copySync(f.path, `${out}/${pkg._target}/${t}`)
-          fs.chmodSync(`${out}/${pkg._target}/${t}`, parseInt(`0${fileMode}`, 8))
+          chmodRegularFile(`${out}/${pkg._target}/${t}`)
         })
         _exec(`chmod ${dirMode} $(find ${pkg._out} -type d)`)
         _exec(`dpkg-deb --build ${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`,

--- a/test/control
+++ b/test/control
@@ -1,8 +1,8 @@
 Package: demo
 Version: 0.1-2
-Section: base
+Section: devel
 Priority: optional
 Architecture: i386
 Maintainer: Mr. Apt <apt@nowhere.tld>
-Description: A dummy package
+Description: Dummy package
  Long description starts here...


### PR DESCRIPTION
…in changelog; access writes corrections for folders and files: 755 and 644.

I catch race condition in changelog gzip part of code. Gzip very often finishes after `dpkg-deb` :-((. So I remove this beautiful and stream based code and put my one that works in all cases.

I always add some minor changes in `changelog` method to satisfy Debian policy.

So `lintian -c` now generates 3 errors `dir-or-file-in-opt` for `/opt/*` and 1 warning for `.gitignore`.
