### PR TITLE
Fix 'control directory has bad permissions 777 (must be >=0755 and <=0775)'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,32 +177,39 @@ module.exports = function (pkg) {
         })
       }
       */
-      const ctrlf = ctrl.join('\n')
-      fs.outputFile(`${out}/DEBIAN/control`, ctrlf.substr(0, ctrlf.length - 1),
-      function (err) {
+      
+      fs.mkdir(`${out}/DEBIAN`, '0775', function (err) {
         if (err) {
           cb(new gutil.PluginError(P, err))
           // return
         }
-        files.map(function (f) {
-          let t = f.path.split('/')
-          t = t[t.length - 1]
-          fs.copySync(f.path, `${out}/${pkg._target}/${t}`)
-          chmodRegularFile(`${out}/${pkg._target}/${t}`)
-        })
-        _exec(`chmod ${dirMode} $(find ${pkg._out} -type d)`)
-        _exec(`dpkg-deb --build ${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`,
-        function (err, stdout, stderr) {
-          if (pkg._clean) {
-            fs.removeSync(`${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`)
+        const ctrlf = ctrl.join('\n')
+        fs.outputFile(`${out}/DEBIAN/control`, ctrlf.substr(0, ctrlf.length - 1),
+        function (err) {
+          if (err) {
+            cb(new gutil.PluginError(P, err))
+            // return
           }
-          if (pkg._verbose && stdout.length > 1) {
-            gutil.log(stdout.trim() + '\n')
-          }
-          if (stderr) {
-            gutil.log(gutil.colors.red(stderr.trim()))
-          }
-          cb(err)
+          files.map(function (f) {
+            let t = f.path.split('/')
+            t = t[t.length - 1]
+            fs.copySync(f.path, `${out}/${pkg._target}/${t}`)
+            chmodRegularFile(`${out}/${pkg._target}/${t}`)
+          })
+          _exec(`chmod ${dirMode} $(find ${pkg._out} -type d)`)
+          _exec(`dpkg-deb --build ${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`,
+          function (err, stdout, stderr) {
+            if (pkg._clean) {
+              fs.removeSync(`${pkg._out}/${pkg.package}_${pkg.version}_${pkg.architecture}`)
+            }
+            if (pkg._verbose && stdout.length > 1) {
+              gutil.log(stdout.trim() + '\n')
+            }
+            if (stderr) {
+              gutil.log(gutil.colors.red(stderr.trim()))
+            }
+            cb(err)
+          })
         })
       })
     })


### PR DESCRIPTION
When attempting to build DPKG files on a WSL environment I encountered the above error, output from dpkg itself.

First I tried using the 'dirMode' option of outputFile but it didn't fix the issue, creating the control directory first fixes it.

https://www.npmjs.com/package/output-file#optionsdirmode

Note: PR recreated because I accidentally deleted my gulp-debian fork repo on github.

Note, diff looks big but it's just indentation.

with regards to the failing tests, can you take a look? I don't currently have time. I'm a super n00b when it comes to npm, node, etc. likely there's a test which needs to cleanup after itself before the next one runs as I think creating the directory fails if it already exists. If you have any code change suggestions let me know.

FYI, I'm here because a pre-exsting gulp task doesn't work for me on WSL, it uses the 'clean: true' option which is likely why this PR fixes my issues but causes the tests to file.

